### PR TITLE
Refactored and added exponential backoff to 42crunch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 gem "open3", "~> 0.1.2"
 gem 'rest-client'
+gem 'retries'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    retries (0.0.5)
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.5)
@@ -377,6 +378,7 @@ DEPENDENCIES
   rails (~> 7.0.4, >= 7.0.4.2)
   rails-controller-testing
   rest-client
+  retries
   rspec
   rspec-rails
   rubocop-govuk

--- a/app/lib/linters/crunch_api.rb
+++ b/app/lib/linters/crunch_api.rb
@@ -1,4 +1,5 @@
 require 'rest-client'
+require 'retries'
 require 'base64'
 module Linters
 
@@ -10,75 +11,59 @@ module Linters
       @base_url = base_url
     end
 
+    # Post the file to 42Crunch according to their API v1 "Create an API (from file)" spec
+    # https://www.postman.com/get-42crunch/workspace/42crunch-api/request/13761657-335bcb36-c68f-43a1-823d-741b62b55bc6
+    def create_api
+    result = RestClient.post(URI.join(@base_url, "/api/v1/apis").to_s,
+      { # Body of the request
+        cid: ENV['COLLECTION_ID'], # Collection id, returned by "Create a collection"
+        name: File.basename(file.path, ".*"), # API Display Name
+        yaml: false, # Set to true if the specification file was converted to JSON from YAML
+        specfile: file # Raw OAS file in JSON format - YAML is not supported
+      },
+      { # Request headers
+      'X-API-KEY': ENV['CRUNCH_API_KEY']
+      })
+
+      return result
+    end
+
+    # Use the created API ID to get the linting results from 42Crunch using their
+    # API V1 "Retrieve and visualize a security audit report" spec
+    # https://www.postman.com/get-42crunch/workspace/42crunch-api/request/13761657-85a4551d-8350-4744-ba62-e4289103ec81
+    # @param id [String] the ID of the report to retrieve
+    # @return [String] the raw JSON response
+    def retrieve_report(id)
+      url = URI.join(@base_url, "/api/v1/apis/", id + "/", "assessmentreport").to_s
+      puts "Retrieving #{url}"
+      result = RestClient.get(url,
+      { # Request headers
+      'X-API-KEY': ENV['CRUNCH_API_KEY']
+      })
+
+      return result
+    end
+
     # Lints an unploaded file with 42crunch.
     #
     # @param file [File] the file to be linted
     # @return [String] the raw JSON response
     def lint_to_json
 
-      # Post the file to 42Crunch according to their API v1 "Create an API (from file)" spec
-      # https://www.postman.com/get-42crunch/workspace/42crunch-api/request/13761657-335bcb36-c68f-43a1-823d-741b62b55bc6
-      begin
-        create_response = RestClient.post(URI.join(@base_url, "/api/v1/apis").to_s,
-        { # Body of the request
-          cid: ENV['COLLECTION_ID'], # Collection id, returned by "Create a collection"
-          name: File.basename(file.path, ".*"), # API Display Name
-          yaml: false, # Set to true if the specification file was converted to JSON from YAML
-          specfile: file # Raw OAS file in JSON format - YAML is not supported
-        },
-        { # Request headers
-        'X-API-KEY': ENV['CRUNCH_API_KEY']
-        })
-      rescue RestClient::MovedPermanently,
-             RestClient::Found,
-             RestClient::TemporaryRedirect => err
-        err.response.follow_redirection
-      rescue RestClient::Unauthorized, RestClient::Forbidden => err
-        raise 'Access denied by 42Crunch API'
-      rescue RestClient::RequestFailed => err
-        raise '42Crunch Create Request Failed'
-      end
+      # Create an API for the file we initialized this class with then
+      # parse the JSON response to get the ID needed to get the linting results
+      created_api_id = JSON.parse(create_api())["desc"]["id"]
 
-      # Parse the JSON response to get the ID needed to get the linting results
-      # (which requires a second API call)
-      begin
-        created_api_id = JSON.parse(create_response)["desc"]["id"]
-      rescue JSON::ParserError
-        raise "Couldn't parse JSON response from 42Crunch Create API V1"
+      # We need a second request to retrieve the actual report.
+      # If we try to get the report too quickly 42crunch will return a 404 error
+      # So we need to use exponential backoff from the 'retries' gem
+      report_response = ""
+      with_retries(:max_tries => 10, :rescue => [RestClient::RequestFailed]) do
+        report_response = retrieve_report(created_api_id)
       end
-
-      # Use the created API ID to get the linting results from 42Crunch using their
-      # API V1 "Retrieve and visualize a security audit report" spec
-      # https://www.postman.com/get-42crunch/workspace/42crunch-api/request/13761657-85a4551d-8350-4744-ba62-e4289103ec81
-      begin
-        report_response = RestClient.get(URI.join(@base_url, "/api/v1/apis/", created_api_id + "/", "assessmentreport").to_s,
-        { # Request headers
-        'X-API-KEY': ENV['CRUNCH_API_KEY']
-        })
-      rescue RestClient::MovedPermanently,
-             RestClient::Found,
-             RestClient::TemporaryRedirect => err
-        err.response.follow_redirection
-      rescue RestClient::Unauthorized, RestClient::Forbidden => err
-        raise 'Access denied by 42Crunch API'
-      rescue RestClient::RequestFailed => err
-        raise '42Crunch Retrieve Report Request Failed'
-      end
-
 
       # Parse the JSON response to get the report data
-      begin
-        report_data = JSON.parse(report_response)["data"]
-      rescue JSON::ParserError
-        raise "Couldn't parse JSON response from 42Crunch Retrieve Report API V1"
-      end
-
-      begin
-        decoded_report_data = Base64.decode64(report_data)
-      rescue Base64::Error
-        raise "Couldn't decode data from 42Crunch Retrieve Report API V1"
-      end
-
+      decoded_report_data = Base64.decode64(JSON.parse(report_response)["data"])
 
       return decoded_report_data
 


### PR DESCRIPTION
The first stage of refactoring 42crunch API code.

Added exponential backoff because 42crunch returns a 404 error if we try to retrieve the report too quickly after uploading when it is busy.