### PR TITLE
default the selected ruleset to the gov ruleset

### DIFF
--- a/app/views/rulesets/index.html.erb
+++ b/app/views/rulesets/index.html.erb
@@ -12,12 +12,12 @@
           </legend>
           <div class="govuk-radios" data-module="govuk-radios">
             <div class="govuk-radios__item">
-              <%= text_field_tag("ruleset_name", "security_ruleset", class: "govuk-radios__input", type: "radio", name: "ruleset_name" ) %>
-              <%= label_tag("security_ruleset", "Security ruleset", class: "govuk-label govuk-radios__label", for: "security-ruleset") %>
+              <%= text_field_tag("ruleset_name", "government_ruleset", class: "govuk-radios__input", type: "radio", name: "ruleset_name", checked: true) %>
+              <%= label_tag("gov-ruleset", "UK government ruleset", class: "govuk-label govuk-radios__label", for: "gov-ruleset") %>
             </div>
             <div class="govuk-radios__item">
-              <%= text_field_tag("ruleset_name", "government_ruleset", class: "govuk-radios__input", type: "radio", name: "ruleset_name") %>
-              <%= label_tag("gov-ruleset", "UK government ruleset", class: "govuk-label govuk-radios__label", for: "gov-ruleset") %>
+              <%= text_field_tag("ruleset_name", "security_ruleset", class: "govuk-radios__input", type: "radio", name: "ruleset_name" ) %>
+              <%= label_tag("security_ruleset", "Security ruleset", class: "govuk-label govuk-radios__label", for: "security-ruleset") %>
             </div>
           </div>
         </fieldset>


### PR DESCRIPTION
As discussed with @georgeschena and @DarrylMultisided this morning, we want the radio buttons to default to the gov selection so there is no chance of a ruleset not being selected and no need for errors to be displayed on this form.

https://cddodatamarketplace.atlassian.net/browse/GDX-540