### PR TITLE
Increase the session timeout 

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,2 +1,2 @@
-Rails.application.config.session_store :active_record_store, key: "cddo-linter-session", expire_after: 20.minutes.to_i
+Rails.application.config.session_store :active_record_store, key: "cddo-linter-session", expire_after: 48.hours.to_i
 ActiveRecord::SessionStore::Session.serializer = :json


### PR DESCRIPTION
We need to increase the session timeout so users have plenty of time to use the same open api file without having to re upload. 