### PR TITLE
Fix formatting of bold content

### DIFF
--- a/config/locales/rules.yml
+++ b/config/locales/rules.yml
@@ -22,20 +22,24 @@ en:
 
       The following is an example of an OpenAPI document that is using an old version. 3.1.0 is the current latest minor version, so 3.0.0 is out of date:
 
-          **openapi: 3.0.0**
-          info:
-            title: ''
-            version: '1.0.0'
+      <pre>
+      <b>openapi: 3.0.0</b>
+      info:
+        title: ''
+        version: '1.0.0'
+      </pre>
 
       Remediation
       -----------
 
       The following is an example of an OpenAPI document using the latest version of OpenAPI:
 
-          **openapi: 3.1.0**
-          info:
-            title: ''
-            version: '1.0.0'
+      <pre>
+      <b>openapi: 3.1.0</b>
+      info:
+        title: ''
+        version: '1.0.0'
+      </pre>
 
     license-strict: |
       License must be Apache 2.0
@@ -51,28 +55,32 @@ en:
 
       The following is an example of an OpenAPI document which is referencing a proprietary license type:
 
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-            **license:**
-              **name: EULA**
-              **identifier: EULA**
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+        <b>license:</b>
+          <b>name: EULA</b>
+          <b>identifier: EULA</b>
+      paths: {}
+      </pre>
 
       Remediation
       -----------
 
       The following is an example of an OpenAPI document which uses the correct license type. Apache 2.0 is an example of an open source license:
 
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-            **license:**
-              **name: Apache 2.0**
-              **identifier: Apache-2.0**
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+        <b>license:</b>
+          <b>name: Apache 2.0</b>
+          <b>identifier: Apache-2.0</b>
+      paths: {}
+      </pre>
 
 
     license-url: |
@@ -89,30 +97,34 @@ en:
 
       The following is an example of an OpenAPI document which has the wrong url for the license:
   
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-            license:
-              name: Apache 2.0
-              identifier: Apache-2.0
-              **url: https://www.example.com**
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+        license:
+          name: Apache 2.0
+          identifier: Apache-2.0
+          <b>url: https://www.example.com</b>
+      paths: {}
+      </pre>
 
       Remediation
       -----------
 
       The following is an example of an OpenAPI document which uses the correct license url:
 
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-            license:
-              name: Apache 2.0
-              identifier: Apache-2.0
-              **url: https://www.apache.org/licenses/LICENSE-2.0**
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+        license:
+          name: Apache 2.0
+          identifier: Apache-2.0
+          <b>url: https://www.apache.org/licenses/LICENSE-2.0</b>
+      paths: {}
+      </pre>
 
     not-acceptable: |
       Not acceptable
@@ -127,30 +139,34 @@ en:
       
       The following is an example of how an operation missing a 406 response might look:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-            "/":
-              post:
-                responses:
-                  '200': {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+        "/":
+          post:
+            responses:
+              '200': {}
+      </pre>
       
       Remediation
       -----------
       
       The following is how an example of how an operation that does declare a 406 response:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-            "/":
-              post:
-                responses:
-                  **'406': {}**
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+        "/":
+          post:
+            responses:
+              <b>'406': {}</b>
+      </pre>
 
     unsupported-media-type: |
       Unsupported media type
@@ -165,30 +181,34 @@ en:
       
       The following is an example of how an operation missing a 415 response might look:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-            "/":
-              post:
-                responses:
-                  '200': {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+        "/":
+          post:
+            responses:
+              '200': {}
+      </pre>
       
       Remediation
       -----------
       
       The following is how an example of how an operation that does declare a 415 response:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-            "/":
-              post:
-                responses:
-                  **'415': {}**
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+        "/":
+          post:
+            responses:
+              <b>'415': {}</b>
+      </pre>
 
     oas3-minimum: |
       OpenAPI Specification 3 - minimum
@@ -204,20 +224,24 @@ en:
       
       The following is an example of an OpenAPI document not using an up-to-date version. In this example version 2.0.0 is used, which is an old version:
       
-          **openapi: 2.0.0**
-          info:
-            title: ''
-            version: '1.0.0'
+      <pre>
+      <b>openapi: 2.0.0</b>
+      info:
+        title: ''
+        version: '1.0.0'
+      </pre>
       
       Remediation
       -----------
       
       The following is an example of an OpenAPI document using the latest major version of OpenAPI, which is currently 3.1.0:
       
-          **openapi: 3.1.0**
-          info:
-            title: ''
-            version: '1.0.0'
+      <pre>
+      <b>openapi: 3.1.0</b>
+      info:
+        title: ''
+        version: '1.0.0'
+      </pre>
 
     license: |
       License
@@ -232,28 +256,32 @@ en:
       
       The following is an example of an OpenAPI document which is referencing a closed source license type:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-            **license:**
-              **name: EULA**
-              **identifier: EULA**
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+        <b>license:</b>
+          <b>name: EULA</b>
+          <b>identifier: EULA</b>
+      paths: {}
+      </pre>  
       
       Remediation
       -----------
       
       The following is an example of an OpenAPI document which uses one of the popular licenses listed on the opensource site:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-            **license:**
-              **name: Apache 2.0**
-              **identifier: Apache-2.0**
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+        <b>license:</b>
+          <b>name: Apache 2.0</b>
+          <b>identifier: Apache-2.0</b>
+      paths: {}
+      </pre>
 
     operation-id: |
       Operation ID
@@ -275,29 +303,33 @@ en:
       
       The following is an example of an OpenAPI document which defines an operation that is missing an `operationId`. The `ping` path has a `get` operation which doesn't have an `operationId`:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-            /ping:
-              get:
-                summary: Checks if the server is alive
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+        /ping:
+          get:
+            summary: Checks if the server is alive
+      </pre>
       
       Remediation
       -----------
       
       The following is an example of an OpenAPI document which defines an operation that does have an operationId:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-            /ping:
-              get:
-                summary: Checks if the server is alive
-                **operationId: ping**
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+        /ping:
+          get:
+            summary: Checks if the server is alive
+            <b>operationId: ping</b>
+      </pre>
 
     semver: |
       Semantic Versioning
@@ -312,22 +344,26 @@ en:
       
       Semantic versioning numbers should have a major, minor and patch number. The following is an example of how an incorrect version number could look in your API definition as it is missing a patch number:
         
-          openapi: 3.1.0
-          info:
-            title: ''
-            **version: '1.0'**
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        <b>version: '1.0'</b>
+      paths: {}
+      </pre>
       
       Remediation
       -----------
       
       The following is how a correctly versioned OpenAPI document could look:
               
-          openapi: 3.1.0
-          info:
-            title: ''
-            **version: '1.0.0'**
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        <b>version: '1.0.0'</b>
+      paths: {}
+      </pre>
 
     paths-kebab-case: |
       Paths kebab case
@@ -342,30 +378,34 @@ en:
       
       The following is an example of an OpenAPI document which has a path name that does not use kebab case. In this example, the `path_parameter` class is using snake case (words separated by underscores) rather than kebab case (works separated by hyphens):    
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-            **/path_parameter:**
-              get:
-                summary: Checks if the server is alive
-                operationId: ping
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+        <b>/path_parameter:</b>
+          get:
+            summary: Checks if the server is alive
+            operationId: ping
+      </pre>
       
       Remediation
       -----------
       
       The following is an example of an OpenAPI document which has a path name that does use kebab case:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-            **/path-parameter:**
-              get:
-                summary: Checks if the server is alive
-                operationId: ping
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+        <b>/path-parameter:</b>
+          get:
+            summary: Checks if the server is alive
+            operationId: ping
+      </pre>
 
     oas3-always-use-https: |
       OpenAPI Specification 3 - Always use HTTPS
@@ -380,13 +420,15 @@ en:
       
       The following is an example of how this type of risk could look in your API definition, as the url is using `http` rather than `https`:
       
-          openapi: 3.1.0
-            info:
-            title: ''
-            version: '1.0.0'
-            paths: {}
-            servers:
-              - **url: http://api.example.com**
+      <pre>
+      openapi: 3.1.0
+        info:
+        title: ''
+        version: '1.0.0'
+        paths: {}
+        servers:
+          - <b>url: http://api.example.com</b>
+      </pre>
       
       
       Possible Exploit Scenario
@@ -405,13 +447,15 @@ en:
       
       The following is how using `https` should look in your API definition:
       
-          openapi: 3.1.0
-            info:
-            title: ''
-            version: '1.0.0'
-            paths: {}
-            servers:
-              - **url: https://api.example.com**
+      <pre>
+      openapi: 3.1.0
+        info:
+        title: ''
+        version: '1.0.0'
+        paths: {}
+        servers:
+          - <b>url: https://api.example.com</b>
+      </pre>
 
     oas2-always-use-https: |
       OpenAPI Specification 2 - Always use HTTPS
@@ -426,13 +470,15 @@ en:
       
       The following is an example of how this type of risk could look in your API definition, as the url is using `http` rather than `https`:
       
-          openapi: 3.1.0
-            info:
-            title: ''
-            version: '1.0.0'
-            paths: {}
-            servers:
-              - **url: http://api.example.com**
+      <pre>
+      openapi: 3.1.0
+        info:
+        title: ''
+        version: '1.0.0'
+        paths: {}
+        servers:
+          - <b>url: http://api.example.com</b>
+      <pre>
       
       
       Possible Exploit Scenario
@@ -451,13 +497,15 @@ en:
       
       The following is how using `https` should look in your API definition:
       
-          openapi: 3.1.0
-            info:
-            title: ''
-            version: '1.0.0'
-            paths: {}
-            servers:
-              - **url: https://api.example.com**
+      <pre>
+      openapi: 3.1.0
+        info:
+        title: ''
+        version: '1.0.0'
+        paths: {}
+        servers:
+          - <b>url: https://api.example.com</b>
+      </pre>
 
     no-x-headers: |
       No X-Headers
@@ -472,37 +520,41 @@ en:
       
       The following is an example of how this might look in your OpenAPI document. In this example the name of the header begins with `X-`:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-            "/ping":
-              get:
-                parameters:
-                  - in: header
-                    **name: X-Request-ID**
-                    schema:
-                      type: string
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+        "/ping":
+          get:
+            parameters:
+              - in: header
+                <b>name: X-Request-ID</b>
+                schema:
+                  type: string
+      </pre>
         
       Remediation
       -----------
       
       The following is how the request header would look without the `X-` prefix:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-            /ping:
-              get:
-                summary: Checks if the server is alive
-                parameters:
-                  - in: header
-                    **name: Request-ID**
-                    schema:
-                      type: string
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+        /ping:
+          get:
+            summary: Checks if the server is alive
+            parameters:
+              - in: header
+                <b>name: Request-ID</b>
+                schema:
+                  type: string
+      </pre>
 
     no-x-response-headers: |
       No X response headers
@@ -517,42 +569,46 @@ en:
       
       The following is an example of how this might look in your OpenAPI document. This would be invalid because the name of the response header begins with `X-`:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-          "/ping":
-            get:
-              summary: Checks if the server is alive.
-              responses:
-                '200':
-                  description: OK
-                  headers:
-                    **X-RateLimit-Limit:**
-                      schema:
-                        type: integer
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+      "/ping":
+        get:
+          summary: Checks if the server is alive.
+          responses:
+            '200':
+              description: OK
+              headers:
+                <b>X-RateLimit-Limit:</b>
+                  schema:
+                    type: integer
+      </pre>
       
       Remediation
       -----------
       
       The following is how the request header would look without the `X-` prefix:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths:
-          "/ping":
-            get:
-              summary: Checks if the server is alive.
-              responses:
-                '200':
-                  description: OK
-                  headers:
-                    **RateLimit-Limit:**
-                      schema:
-                        type: integer
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths:
+      "/ping":
+        get:
+          summary: Checks if the server is alive.
+          responses:
+            '200':
+              description: OK
+              headers:
+                <b>RateLimit-Limit:</b>
+                  schema:
+                    type: integer
+      </pre>
 
     description: |
       
@@ -568,23 +624,27 @@ en:
       
       The following is an example of how your OpenAPI document might look if it's missing a `description` from the `info` section:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths: {}
+      </pre>
       
       Remediation
       -----------
       
       The following is an example of an OpenAPI document with a description:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-            **description: 'A description of the API.'**
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+        <b>description: 'A description of the API.'</b>
+      paths: {}
+      </pre>
 
     contact: |
       Contact
@@ -599,27 +659,31 @@ en:
       
       The following is an example of how your OpenAPI document might look if contact information is missing from the `info` object:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths: {}
+      </pre>
       
       Remediation
       -----------
       
       The following is an example of an OpenAPI document with contact information included:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-            **contact: {**
-              **"name": "API Support",**
-              **"url": "https://www.example.com/support",**
-              **"email": "support@example.com"**
-            **}**
-          paths: {}
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+        <b>contact: {<b>
+          <b>"name": "API Support",</b>
+          <b>"url": "https://www.example.com/support",</b>
+          <b>"email": "support@example.com"</b>
+        <b>}</b>
+      paths: {}
+      </pre>
 
     domain-name-length: |
       Domain name length
@@ -634,26 +698,30 @@ en:
       
       The following is an example of a domain name which would fail this rule because it is too long:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths: {}
-          servers:
-            - **url: 'https://vehicle-registration-number-vehicle-registration-number-vehicles.api.gov.uk'**
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths: {}
+      servers:
+        - <b>url: 'https://vehicle-registration-number-vehicle-registration-number-vehicles.api.gov.uk'</b>
+      </pre>
       
       Remediation
       -----------
       
       The following is an example of a valid domain name, which is between 3 and 63 characters long:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths: {}
-          servers:
-            - **url: 'https://vehicle-registration-number.api.gov.uk'**
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths: {}
+      servers:
+        - <b>url: 'https://vehicle-registration-number.api.gov.uk'</b>
+      </pre>
 
     domain-name-characters: |
       Domain name characters
@@ -668,23 +736,27 @@ en:
       
       The following is an example of a domain name which would fail this rule because it contains an asterisk, which is an invalid character:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths: {}
-          servers:
-            - **url: 'https://vehicle-registration-number-*.api.gov.uk'**
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths: {}
+      servers:
+        - <b>url: 'https://vehicle-registration-number-*.api.gov.uk'</b>
+      </pre>
       
       Remediation
       -----------
       
       The following is an example of a valid domain name, which does not contain invalid characters:
       
-          openapi: 3.1.0
-          info:
-            title: ''
-            version: '1.0.0'
-          paths: {}
-          servers:
-            - **url: 'https://vehicle-registration-number.api.gov.uk'**
+      <pre>
+      openapi: 3.1.0
+      info:
+        title: ''
+        version: '1.0.0'
+      paths: {}
+      servers:
+        - <b>url: 'https://vehicle-registration-number.api.gov.uk'</b>
+      </pre>


### PR DESCRIPTION
Using double asterisks doesn't work inside code blocks in markdown. However we should be able to use html tags to have bold text inside a `pre` block.