### PR TITLE
Add index view of rules

### DIFF
--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 class RulesController < ApplicationController
+  def index
+    @rules = RuleText.rules
+  end
+
   def show
     @rule_name = params[:id]
   end

--- a/app/lib/rule_text.rb
+++ b/app/lib/rule_text.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class RuleText
+  RULE_LOCATION = [:en, :rules].freeze
+
+  def self.rules
+    @rules ||= begin
+      I18n.t('foo') # Do a lookup to ensure I18n backend is populated
+      rules = I18n.config.backend.translations.dig(*RULE_LOCATION)
+      rules.transform_values {|rule| rule.split("\n").first}
+    end
+  end
+end

--- a/app/views/rules/index.html.erb
+++ b/app/views/rules/index.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">GOV.UK OpenAPI Linting Rules</h1>
+
+    <p class="govuk-body">Information on the following rules are available here:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <% @rules.each do |rule, text| %>
+        <li>
+          <%= govuk_link_to "#{text} (#{rule})", rule_path(rule) %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :rulesets, only: %i[index create]
   resource :government_ruleset, only: %i[show create]
   resource :security_ruleset, only: %i[show create]
-  resources :rules, only: %i[show]
+  resources :rules, only: %i[show index]
 
   scope via: :all do
     get "/404", to: "errors#not_found"

--- a/spec/lib/rule_text_spec.rb
+++ b/spec/lib/rule_text_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe RuleText do
+  let(:locale) { YAML.load_file(Rails.root.join('config/locales/rules.yml')) }
+
+  describe '.rules' do
+    subject(:rules) { described_class.rules }
+
+    it 'is a hash' do
+      expect(rules).to be_a(Hash)
+    end
+
+    it 'has the keys from the locale file' do
+      expect(rules.keys.map(&:to_s)).to contain_exactly(*locale.dig("en", "rules").keys)
+    end
+
+    it 'has values which contain the first line of the translation' do
+      expect(rules[:'license-url']).to eq('License URL')
+    end
+  end
+end

--- a/spec/requests/rules_spec.rb
+++ b/spec/requests/rules_spec.rb
@@ -21,4 +21,15 @@ RSpec.describe "Rules", type: :request do
     end
   end
 
+  describe "GET rules/" do
+    it "returns http success" do
+      get rules_path
+      expect(response).to have_http_status(:success)
+    end
+
+    it "lists the rules" do
+      get rules_path
+      expect(response.body).to include(RuleText.rules.values.first)
+    end
+  end
 end


### PR DESCRIPTION
The new index page lists the available rules and provides links to each one.

The new page looks like this:

![rules_index](https://user-images.githubusercontent.com/119297020/226880254-b000d137-1e07-4d7d-a629-7887966c9548.png)
