### PR TITLE
Fix for showing friendly ruleset name

### DIFF
--- a/app/views/government_rulesets/show.html.erb
+++ b/app/views/government_rulesets/show.html.erb
@@ -18,7 +18,7 @@
           Ruleset:
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @ruleset_name %>
+          <%= t("rulesets.#{@ruleset_name}.name") %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">


### PR DESCRIPTION
Display the friendly ruleset names on the results page.