### PR TITLE
fixed encoding issue

### DIFF
--- a/app/controllers/security_rulesets_controller.rb
+++ b/app/controllers/security_rulesets_controller.rb
@@ -25,7 +25,7 @@ class SecurityRulesetsController < ApplicationController
     return File.read("fakecrunchresults.json") if ENV["BYPASS_API"] == "true"
 
     Tempfile.open(upload.oas_file.key) do |oas_file|
-      oas_file.write(upload.oas_file.download)
+      oas_file.write(upload.oas_file.download.encode('utf-8', 'binary', invalid: :replace, undef: :replace))
       oas_file.rewind
       Linters::CrunchApi::Fetch.new(file: oas_file).lint_to_json
     end

--- a/app/controllers/security_rulesets_controller.rb
+++ b/app/controllers/security_rulesets_controller.rb
@@ -25,7 +25,8 @@ class SecurityRulesetsController < ApplicationController
     return File.read("fakecrunchresults.json") if ENV["BYPASS_API"] == "true"
 
     Tempfile.open(upload.oas_file.key) do |oas_file|
-      oas_file.write(upload.oas_file.download.encode('utf-8', 'binary', invalid: :replace, undef: :replace))
+      content = upload.oas_file.download.encode('utf-8', 'binary', invalid: :replace, undef: :replace)
+      oas_file.write content
       oas_file.rewind
       Linters::CrunchApi::Fetch.new(file: oas_file).lint_to_json
     end


### PR DESCRIPTION
I've tried various different ways of fixing this issue, it seems the best method is to force encoding on the file we upload when processing it specifically for the crunch api request.

The code here will handle any characters that don't fit the utf-8 format.